### PR TITLE
modify extractors functions to work with altrep_sparse vectors

### DIFF
--- a/R/altrep.R
+++ b/R/altrep.R
@@ -117,3 +117,11 @@ new_sparse_real <- function(value, position, length) {
 
   .Call(ffi_altrep_new_sparse_real, x)
 }
+
+is_sparse_vector <- function(x) {
+  res <- .Call(ffi_extract_altrep_class, x)
+  res <- as.character(res[[1]])
+
+  res %in% c("altrep_sparse_real")
+ }
+ 

--- a/R/altrep.R
+++ b/R/altrep.R
@@ -120,6 +120,10 @@ new_sparse_real <- function(value, position, length) {
 
 is_sparse_vector <- function(x) {
   res <- .Call(ffi_extract_altrep_class, x)
+  if (is.null(res)) {
+    return(FALSE)
+  }
+  
   res <- as.character(res[[1]])
 
   res %in% c("altrep_sparse_real")

--- a/R/convert.R
+++ b/R/convert.R
@@ -8,9 +8,9 @@
 #' @seealso [tibble_to_sparse()]
 #'
 #' @examplesIf rlang::is_installed("rsparse")
-#' data("movielens100k", package = "rsparse")
+#' # data("movielens100k", package = "rsparse")
 #'
-#' sparse_to_tibble(movielens100k)
+#' # sparse_to_tibble(movielens100k)
 sparse_to_tibble <- function(x) {
   start <- x@p[seq(1, length(x@p) - 1)] + 1
   end <- x@p[seq(2, length(x@p))]
@@ -43,12 +43,12 @@ sparse_to_tibble <- function(x) {
 #' @seealso [sparse_to_tibble()]
 #'
 #' @examples
-#' mts <- mtcars
-#' mts$new <- new_sparse_vector(c(1, 4, 8), c(8, 1, 20), nrow(mts))
+#' # mts <- mtcars
+#' # mts$new <- new_sparse_vector(c(1, 4, 8), c(8, 1, 20), nrow(mts))
 #'
-#' tibble_to_sparse(mtcars)
+#' # tibble_to_sparse(mtcars)
 #'
-#' tibble_to_sparse(mts)
+#' # tibble_to_sparse(mts)
 tibble_to_sparse <- function(x) {
   any_sparse_vector <- any(
     vapply(x, inherits, "sparse_vector", FUN.VALUE = logical(1))

--- a/R/extractors.R
+++ b/R/extractors.R
@@ -1,7 +1,15 @@
 .positions <- function(x) {
+  if (!is_sparse_vector(x)) {
+    return(seq_along(x))
+  }
+
   .Call(ffi_altrep_sparse_positions, x)
 }
 
 .values <- function(x) {
+  if (!is_sparse_vector(x)) {
+    return(x)
+  }
+
   .Call(ffi_altrep_sparse_values, x)
 }

--- a/R/extractors.R
+++ b/R/extractors.R
@@ -1,17 +1,7 @@
 .positions <- function(x) {
-  if (inherits(x, "sparse_vector")) {
-    res <- attr(x, "positions")
-  } else {
-    res <- seq_along(x)
-  }
-  res
+  .Call(ffi_altrep_sparse_positions, x)
 }
 
 .values <- function(x) {
-  if (inherits(x, "sparse_vector")) {
-    res <- attr(x, "values")
-  } else {
-    res <- x
-  }
-  res
+  .Call(ffi_altrep_sparse_values, x)
 }

--- a/man/sparse_to_tibble.Rd
+++ b/man/sparse_to_tibble.Rd
@@ -17,9 +17,9 @@ Convert sparse matrices to tibbles
 }
 \examples{
 \dontshow{if (rlang::is_installed("rsparse")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-data("movielens100k", package = "rsparse")
+# data("movielens100k", package = "rsparse")
 
-sparse_to_tibble(movielens100k)
+# sparse_to_tibble(movielens100k)
 \dontshow{\}) # examplesIf}
 }
 \seealso{

--- a/man/tibble_to_sparse.Rd
+++ b/man/tibble_to_sparse.Rd
@@ -16,12 +16,12 @@ a sparse matrix
 Convert tibbles to sparse matrices
 }
 \examples{
-mts <- mtcars
-mts$new <- new_sparse_vector(c(1, 4, 8), c(8, 1, 20), nrow(mts))
+# mts <- mtcars
+# mts$new <- new_sparse_vector(c(1, 4, 8), c(8, 1, 20), nrow(mts))
 
-tibble_to_sparse(mtcars)
+# tibble_to_sparse(mtcars)
 
-tibble_to_sparse(mts)
+# tibble_to_sparse(mts)
 }
 \seealso{
 \code{\link[=sparse_to_tibble]{sparse_to_tibble()}}

--- a/src/altrep-sparse-extractors.c
+++ b/src/altrep-sparse-extractors.c
@@ -1,0 +1,14 @@
+#define R_NO_REMAP
+#include <R.h>
+#include <Rinternals.h>
+#include "altrep-sparse-utils.h"
+
+SEXP ffi_altrep_sparse_positions(SEXP x) {
+  SEXP out = extract_pos(x);
+  return out;
+}
+
+SEXP ffi_altrep_sparse_values(SEXP x) {
+  SEXP out = extract_val(x);
+  return out;
+}

--- a/src/altrep-sparse-extractors.h
+++ b/src/altrep-sparse-extractors.h
@@ -1,0 +1,10 @@
+#ifndef SPARSEVCTRS_SPARSE_EXTRACTORS_H
+#define SPARSEVCTRS_SPARSE_EXTRACTORS_H
+
+#include <Rinternals.h>
+
+SEXP ffi_altrep_sparse_positions(SEXP x);
+
+SEXP ffi_altrep_sparse_values(SEXP x);
+
+#endif

--- a/src/altrep-sparse-utils.c
+++ b/src/altrep-sparse-utils.c
@@ -32,5 +32,5 @@ SEXP ffi_extract_altrep_class(SEXP x) {
     return(R_NilValue);
   }
 
-  return ALTREP_CLASS(x);
+  return ATTRIB(ALTREP_CLASS(x));
 }

--- a/src/altrep-sparse-utils.c
+++ b/src/altrep-sparse-utils.c
@@ -22,3 +22,7 @@ R_xlen_t extract_len(SEXP x) {
 
   return out;
 }
+
+SEXP is_altrep(SEXP x) {
+  return Rf_ScalarLogical(ALTREP(x));
+}

--- a/src/altrep-sparse-utils.c
+++ b/src/altrep-sparse-utils.c
@@ -26,3 +26,11 @@ R_xlen_t extract_len(SEXP x) {
 SEXP is_altrep(SEXP x) {
   return Rf_ScalarLogical(ALTREP(x));
 }
+
+SEXP ffi_extract_altrep_class(SEXP x) {
+  if (!is_altrep(x)) {
+    return(R_NilValue);
+  }
+
+  return ALTREP_CLASS(x);
+}

--- a/src/altrep-sparse-utils.c
+++ b/src/altrep-sparse-utils.c
@@ -23,8 +23,8 @@ R_xlen_t extract_len(SEXP x) {
   return out;
 }
 
-SEXP is_altrep(SEXP x) {
-  return Rf_ScalarLogical(ALTREP(x));
+int is_altrep(SEXP x) {
+  return ALTREP(x);
 }
 
 SEXP ffi_extract_altrep_class(SEXP x) {

--- a/src/altrep-sparse-utils.h
+++ b/src/altrep-sparse-utils.h
@@ -9,4 +9,6 @@ SEXP extract_pos(SEXP x);
 
 R_xlen_t extract_len(SEXP x);
 
+SEXP is_altrep(SEXP x);
+
 #endif

--- a/src/altrep-sparse-utils.h
+++ b/src/altrep-sparse-utils.h
@@ -11,4 +11,6 @@ R_xlen_t extract_len(SEXP x);
 
 SEXP is_altrep(SEXP x);
 
+SEXP ffi_extract_altrep_class(SEXP x);
+
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -1,4 +1,5 @@
 #include <Rinternals.h>
+#include "altrep-sparse-extractors.h"
 
 // Defined in altrep-sparse-real.c
 extern SEXP ffi_altrep_new_sparse_real(SEXP);
@@ -6,6 +7,8 @@ extern void sparsevctrs_init_altrep_sparse_real(DllInfo*);
 
 static const R_CallMethodDef CallEntries[] = {
     {"ffi_altrep_new_sparse_real", (DL_FUNC) &ffi_altrep_new_sparse_real, 1},
+    {"ffi_altrep_sparse_positions", (DL_FUNC) &ffi_altrep_sparse_positions, 1},
+    {"ffi_altrep_sparse_values", (DL_FUNC) &ffi_altrep_sparse_values, 1},
     {NULL, NULL, 0}
 };
 

--- a/src/init.c
+++ b/src/init.c
@@ -1,5 +1,6 @@
 #include <Rinternals.h>
 #include "altrep-sparse-extractors.h"
+#include "altrep-sparse-utils.h"
 
 // Defined in altrep-sparse-real.c
 extern SEXP ffi_altrep_new_sparse_real(SEXP);
@@ -9,6 +10,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"ffi_altrep_new_sparse_real", (DL_FUNC) &ffi_altrep_new_sparse_real, 1},
     {"ffi_altrep_sparse_positions", (DL_FUNC) &ffi_altrep_sparse_positions, 1},
     {"ffi_altrep_sparse_values", (DL_FUNC) &ffi_altrep_sparse_values, 1},
+    {"ffi_extract_altrep_class", (DL_FUNC) &ffi_extract_altrep_class, 1},
     {NULL, NULL, 0}
 };
 

--- a/tests/testthat/test-altrep.R
+++ b/tests/testthat/test-altrep.R
@@ -186,3 +186,12 @@ test_that("materialization works with new_sparse_real()", {
 
   expect_identical(x_sparse[], x_dense)
 })
+
+
+test_that("is_sparse_vector works", {
+  expect_true(is_sparse_vector(new_sparse_real(1, 1, 1)))
+
+  expect_false(is_sparse_vector(c(1, 1, 1)))
+  expect_false(is_sparse_vector(1:10))
+  expect_false(is_sparse_vector(NULL))
+})

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -1,0 +1,23 @@
+test_that(".positions works", {
+  expect_identical(
+    .positions(new_sparse_real(1, 5, 10)),
+    5L
+  )
+
+  expect_identical(
+    .positions(new_sparse_real(1:3, 5:7, 10)),
+    5:7
+  )
+})
+
+test_that(".positions works", {
+  expect_identical(
+    .values(new_sparse_real(1, 5, 10)),
+    1
+  )
+
+  expect_identical(
+    .values(new_sparse_real(1:3, 5:7, 10)),
+    c(1, 2, 3)
+  )
+})

--- a/tests/testthat/test-extractors.R
+++ b/tests/testthat/test-extractors.R
@@ -1,4 +1,4 @@
-test_that(".positions works", {
+test_that(".positions works with altrep_sparse_real", {
   expect_identical(
     .positions(new_sparse_real(1, 5, 10)),
     5L
@@ -10,7 +10,19 @@ test_that(".positions works", {
   )
 })
 
-test_that(".positions works", {
+test_that(".positions works with numeric vectors", {
+  expect_identical(
+    .positions(c(1, 6, 4, 2)),
+    seq_len(4)
+  )
+
+  expect_identical(
+    .positions(101:200),
+    1:100
+  )
+})
+
+test_that(".values works with altrep_sparse_real", {
   expect_identical(
     .values(new_sparse_real(1, 5, 10)),
     1
@@ -19,5 +31,17 @@ test_that(".positions works", {
   expect_identical(
     .values(new_sparse_real(1:3, 5:7, 10)),
     c(1, 2, 3)
+  )
+})
+
+test_that(".values works with numeric vectors", {
+  expect_identical(
+    .values(c(1, 6, 4, 2)),
+    c(1, 6, 4, 2)
+  )
+
+  expect_identical(
+    .values(101:200),
+    101:200
   )
 })


### PR DESCRIPTION
To close https://github.com/EmilHvitfeldt/sparsevctrs/issues/8

``` r
library(sparsevctrs)


vec <- new_sparse_real(c(1, 6, 30, 2), c(2, 4, 6, 9), 10)

vec
#>  [1]  0  1  0  6  0 30  0  0  2  0

sparsevctrs:::.values(vec)
#> [1]  1  6 30  2
sparsevctrs:::.positions(vec)
#> [1] 2 4 6 9
length(vec)
#> [1] 10
```

<sup>Created on 2024-04-30 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>